### PR TITLE
Enable jest plugin rules

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -1,4 +1,5 @@
 module.exports = {
+	extends: ['plugin:jest/recommended', 'plugin:jest/style'],
 	plugins: ['jest'],
 	env: {
 		'jest/globals': true,


### PR DESCRIPTION
## What was the problem?
jest rules were not activated in lisk-base/jest config.
## How did I solve it?
I enabled it.